### PR TITLE
fix(docker): point entrypoint at index.mjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install --omit=dev && rm -rf ~/.npm
 
 EXPOSE 3000
 
-ENTRYPOINT ["node", "index.js"]
+ENTRYPOINT ["node", "index.mjs"]


### PR DESCRIPTION
The Docker image fails at startup with:

  Error: Cannot find module '/app/index.js'

Root cause: the tsup → tsdown migration (4fe71f9) changed the default ESM output extension from `.js` to `.mjs`. `dist/index.mjs` exists; `dist/index.js` does not.

Fix: update the Dockerfile entrypoint to load `index.mjs`, matching the bundler's idiomatic ESM output. No build config override needed.

Verification:
- `pnpm build` produces `dist/index.mjs` and `dist/index.d.mts`
- `pnpm lint` clean (37 files, 0 issues)
- `pnpm test` passes