### PR TITLE
fix(client): remove nested Dialog.CloseTrigger that crashes search dialog

### DIFF
--- a/packages/client/src/components/SearchFileDialog/SearchFileDialog.tsx
+++ b/packages/client/src/components/SearchFileDialog/SearchFileDialog.tsx
@@ -65,9 +65,7 @@ export const SearchFileDialog = () => {
 							<Dialog.Header>
 								<Dialog.Title>Search file</Dialog.Title>
 								<Dialog.CloseTrigger asChild>
-									<CloseButton size="sm" aria-label="Close dialog">
-										<Dialog.CloseTrigger />
-									</CloseButton>
+									<CloseButton size="sm" aria-label="Close dialog" />
 								</Dialog.CloseTrigger>
 							</Dialog.Header>
 							<Dialog.Body>


### PR DESCRIPTION
## Problem

After migrating the client UI to Chakra UI v3 (PR #182), clicking the search button crashes the whole app.

## Root Cause

The migrated `SearchFileDialog` rendered a `<Dialog.CloseTrigger>` nested inside a `<CloseButton>` that was itself wrapped by another `<Dialog.CloseTrigger asChild>`:

```tsx
<Dialog.CloseTrigger asChild>
    <CloseButton size="sm" aria-label="Close dialog">
        <Dialog.CloseTrigger />
    </CloseButton>
</Dialog.CloseTrigger>
```

This produces **two** `<button>` elements with the same `data-part="close-trigger"` and the **same** `id="dialog:_r_0_:close"`. The duplicate id breaks Ark UI's dialog state machine when it looks up the close trigger by id, and the invalid markup crashes React.

The valid pattern for Chakra v3 is just `Dialog.CloseTrigger asChild` around the styled button — no inner trigger:

```tsx
<Dialog.CloseTrigger asChild>
    <CloseButton size="sm" aria-label="Close dialog" />
</Dialog.CloseTrigger>
```

## Verification

- `[x]` Biome lint passes (37 files, no issues)
- `[x]` Tests pass (50/50, 100% coverage)
- `[x]` Client build succeeds
- `[x]` Rendered DOM now has a single `data-part="close-trigger"` element with a unique id