### PR TITLE
feat(client): redesign DownloadableItem card with mono signature typography

### DIFF
--- a/packages/client/src/components/DownloadableItem/DownloadableItem.tsx
+++ b/packages/client/src/components/DownloadableItem/DownloadableItem.tsx
@@ -1,5 +1,16 @@
 import { useBoolean } from "@fluentui/react-hooks";
-import { Flex, HStack, IconButton, Progress, Stack } from "@chakra-ui/react";
+import {
+	Badge,
+	Box,
+	Flex,
+	HStack,
+	Heading,
+	IconButton,
+	Progress,
+	Separator,
+	Stack,
+	Text,
+} from "@chakra-ui/react";
 import { Download, Trash2 } from "lucide-react";
 import prettyMilliseconds from "pretty-ms";
 import { type ComponentProps, useCallback } from "react";
@@ -25,8 +36,16 @@ const buttonActionsMap: Record<string, (downloadableFile: DownloadableFile) => P
 	delete: (downloadableFile: DownloadableFile) => cancelDownload(downloadableFile),
 };
 
-const styleMap: Record<string, IconButtonProps["colorPalette"]> = {
+const buttonPaletteMap: Record<string, IconButtonProps["colorPalette"]> = {
 	delete: "red",
+};
+
+const statusPaletteMap: Record<string, IconButtonProps["colorPalette"]> = {
+	pending: "gray",
+	downloading: "blue",
+	downloaded: "green",
+	error: "red",
+	cancelled: "orange",
 };
 
 export const DownloadableItem = (props: DownloadableItemProps) => {
@@ -40,40 +59,63 @@ export const DownloadableItem = (props: DownloadableItemProps) => {
 	}, [disableButton, props]);
 
 	return (
-		<Stack width="100%">
-			<Flex justifyContent="space-between" alignItems="center">
-				<Stack gap={0}>
-					<div>Name: {downloadableFile.fileName}</div>
-					<div>
-						Location: {downloadableFile.network} - {downloadableFile.channelName} - {downloadableFile.botName}
-					</div>
-					<div>Package number: {downloadableFile.fileNumber}</div>
-					<div>Size: {downloadableFile.fileSize}</div>
-					{downloadableFile.status && <div>Status: {downloadableFile.status}</div>}
-					{Number(downloadableFile.eta) > 0 && <div>ETA: {prettyMilliseconds(Number(downloadableFile.eta))}</div>}
+		<Box bg="bg.panel" borderWidth="1px" borderColor="border.subtle" borderRadius="md" p={4}>
+			<Flex justifyContent="space-between" alignItems="flex-start" gap={3}>
+				<Stack gap={2} flex={1} minW={0}>
+					<Heading size="sm" truncate fontWeight="semibold">
+						{downloadableFile.fileName}
+					</Heading>
+
+					<HStack gap={2} color="fg.muted" fontSize="xs" fontFamily="mono" flexWrap="wrap">
+						<Text>{downloadableFile.network}</Text>
+						<Separator orientation="vertical" height="3" />
+						<Text>{downloadableFile.channelName}</Text>
+						<Separator orientation="vertical" height="3" />
+						<Text>{downloadableFile.botName}</Text>
+						<Separator orientation="vertical" height="3" />
+						<Text>#{downloadableFile.fileNumber}</Text>
+					</HStack>
+
+					<HStack gap={3} fontSize="xs" fontFamily="mono" color="fg.muted" alignItems="center" flexWrap="wrap">
+						<Text>{downloadableFile.fileSize}</Text>
+						{downloadableFile.status && (
+							<Badge
+								colorPalette={statusPaletteMap[downloadableFile.status] ?? "gray"}
+								variant="subtle"
+								size="sm"
+								textTransform="lowercase"
+							>
+								{downloadableFile.status}
+							</Badge>
+						)}
+						{Number(downloadableFile.eta) > 0 && (
+							<Text>ETA {prettyMilliseconds(Number(downloadableFile.eta))}</Text>
+						)}
+					</HStack>
 				</Stack>
-				<HStack gap={2} alignItems="center">
-					{action && (
-						<IconButton
-							aria-label={action}
-							disabled={isButtonDisabled}
-							colorPalette={styleMap[action]}
-							size="sm"
-							onClick={onButtonClick}
-						>
-							{iconsMap[action]}
-						</IconButton>
-					)}
-				</HStack>
+
+				{action && (
+					<IconButton
+						aria-label={action}
+						disabled={isButtonDisabled}
+						colorPalette={buttonPaletteMap[action]}
+						size="sm"
+						variant="ghost"
+						onClick={onButtonClick}
+					>
+						{iconsMap[action]}
+					</IconButton>
+				)}
 			</Flex>
+
 			{Number(downloadableFile.percentage) > 0 && (
-				<Progress.Root mt={2} value={Number(Number(downloadableFile.percentage).toFixed(1))}>
+				<Progress.Root mt={3} size="xs" value={Number(Number(downloadableFile.percentage).toFixed(1))}>
 					<Progress.Track>
 						<Progress.Range />
 					</Progress.Track>
-					<Progress.Label>{`${Number(downloadableFile.percentage).toFixed(1)}%`}</Progress.Label>
+					<Progress.Label fontFamily="mono">{`${Number(downloadableFile.percentage).toFixed(1)}%`}</Progress.Label>
 				</Progress.Root>
 			)}
-		</Stack>
+		</Box>
 	);
 };

--- a/packages/client/test/components/DownloadList.test.tsx
+++ b/packages/client/test/components/DownloadList.test.tsx
@@ -48,7 +48,7 @@ describe("DownloadList", () => {
 
 		render(<DownloadList />, { wrapper: createWrapper() });
 
-		await screen.findByText("Name: test-file.txt");
+		await screen.findByText("test-file.txt");
 	});
 
 	it("should call getDownloads with status filter when provided", async () => {
@@ -88,6 +88,6 @@ describe("DownloadList", () => {
 			expect(getDownloads).toHaveBeenCalled();
 		});
 
-		expect(screen.queryByText(/Name:/)).not.toBeInTheDocument();
+		expect(screen.queryByText("test-file.txt")).not.toBeInTheDocument();
 	});
 });

--- a/packages/client/test/components/DownloadableItem/DownloadableItem.test.tsx
+++ b/packages/client/test/components/DownloadableItem/DownloadableItem.test.tsx
@@ -35,11 +35,13 @@ describe("downloadableItem", () => {
 	it("should render file information correctly", () => {
 		render(<DownloadableItem action={"download"} {...mockFile} />, { wrapper: createWrapper() });
 
-		expect(screen.getByText("Name: test-file.txt")).toBeInTheDocument();
-		expect(screen.getByText(/Location:.*test-network.*test-channel.*test-bot/)).toBeInTheDocument();
-		expect(screen.getByText("Package number: 42")).toBeInTheDocument();
-		expect(screen.getByText("Size: 100MB")).toBeInTheDocument();
-		expect(screen.getByText("Status: pending")).toBeInTheDocument();
+		expect(screen.getByText("test-file.txt")).toBeInTheDocument();
+		expect(screen.getByText("test-network")).toBeInTheDocument();
+		expect(screen.getByText("test-channel")).toBeInTheDocument();
+		expect(screen.getByText("test-bot")).toBeInTheDocument();
+		expect(screen.getByText("#42")).toBeInTheDocument();
+		expect(screen.getByText("100MB")).toBeInTheDocument();
+		expect(screen.getByText("pending")).toBeInTheDocument();
 	});
 
 	it("should render download button when action is download", () => {
@@ -101,20 +103,20 @@ describe("downloadableItem", () => {
 		const fileWithEta = { ...mockFile, eta: 60000 };
 		render(<DownloadableItem action={"download"} {...fileWithEta} />, { wrapper: createWrapper() });
 
-		expect(screen.getByText(/ETA:/)).toBeInTheDocument();
+		expect(screen.getByText(/ETA\s/)).toBeInTheDocument();
 	});
 
 	it("should not render ETA when eta is 0", () => {
 		render(<DownloadableItem action={"download"} {...mockFile} />, { wrapper: createWrapper() });
 
-		expect(screen.queryByText(/ETA:/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/ETA\s/)).not.toBeInTheDocument();
 	});
 
 	it("should not render status when it is not provided", () => {
 		const fileWithoutStatus = { ...mockFile, status: undefined as unknown as "pending" };
 		render(<DownloadableItem action={"download"} {...fileWithoutStatus} />, { wrapper: createWrapper() });
 
-		expect(screen.queryByText(/Status:/)).not.toBeInTheDocument();
+		expect(screen.queryByText("pending")).not.toBeInTheDocument();
 	});
 
 	it("should not render button when action is not provided", () => {

--- a/packages/client/test/components/SearchFileDialog/SearchFileDialog.test.tsx
+++ b/packages/client/test/components/SearchFileDialog/SearchFileDialog.test.tsx
@@ -122,7 +122,7 @@ describe("SearchFileDialog", () => {
 		await user.click(searchButton);
 
 		await waitFor(() => {
-			expect(screen.getByText("Name: search-result.txt")).toBeInTheDocument();
+			expect(screen.getByText("search-result.txt")).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Redesigns the download card from flat `Label: value` text into a proper Chakra UI v3 card surface with semantic structure.

## What changes

**Visual**
- Card surface: `bg.panel` + 1px subtle border + rounded corners + padding (was: bare `Stack`)
- Filename becomes a prominent `Heading` (was: plain `<div>Name: ...`)
- All technical identifiers (network, channel, bot, package #, size, ETA, percentage) render in **monospace** — the IRC/terminal vernacular where this app lives
- Status becomes a colored `Badge` (gray/blue/green/red/orange by state) instead of plain text
- Inline `Separator` between metadata fields instead of " - " text
- IconButton uses `variant="ghost"` so it doesn't overpower the card
- Progress bar uses `size="xs"`

**Code**
- Replaces 6 raw `<div>` elements with Chakra `Text`/`Heading` so the card actually gets theme styling
- Introduces `statusPaletteMap` to give each download state a semantic color
- Renamed `styleMap` → `buttonPaletteMap` for clarity (was overloaded)

## Verification
- `pnpm lint` — clean
- `pnpm test` — 50/50 tests pass, 100% line coverage
- `pnpm build` — succeeds

## Subject grounding (frontend-design)

> Ground design in the subject itself. Spend boldness in one place.

- **Subject:** an XDCC IRC file-transfer queue card
- **Audience:** power users managing multiple bot downloads  
- **Single job:** show transfer state at a glance; let user cancel
- **Signature element:** monospace treatment for technical identifiers — matches the IRC/terminal vernacular of the domain and distinguishes the card from generic SaaS chrome
- **Avoided:** cream+terracotta, near-black+acid-green, broadsheet layouts (the AI-default look cluster)

## Test updates

The previous tests asserted on the old `Label: value` text. Updated to assert on the new bare values that the component renders.