### PR TITLE
feat(client): stack top row vertically on mobile viewports

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -23,14 +23,26 @@ function App() {
 
 	return (
 		<Box maxW="6xl" mx="auto" px={{ base: 4, md: 6 }} py={6}>
-			<Flex justifyContent="space-between" mb={4}>
-				<Flex alignItems="center">
-					<Box mr={2}>Status:</Box>
+			<Flex
+				justifyContent="space-between"
+				alignItems={{ base: "stretch", md: "center" }}
+				direction={{ base: "column", md: "row" }}
+				gap={3}
+				mb={4}
+			>
+				<Flex
+					alignItems="center"
+					gap={2}
+					direction={{ base: "column", md: "row" }}
+					align={{ base: "flex-start", md: "center" }}
+					w={{ base: "100%", md: "auto" }}
+				>
+					<Box alignSelf="flex-start">Status:</Box>
 					<Select.Root
 						collection={dropdownOptions}
 						value={statusOption ? [statusOption] : []}
 						onValueChange={onStatusChange}
-						width="200px"
+						width={{ base: "100%", md: "200px" }}
 					>
 						<Select.HiddenSelect />
 						<Select.Control>


### PR DESCRIPTION
## Summary

Makes the App top row responsive so the controls don't overflow on phone-sized screens.

## Problem

At viewport widths below 768px, the top row overflows: the 200px Select + 'Status:' label + two action buttons exceed the available width. At 320px the file icon button gets clipped off the right edge entirely. Verified via screenshots at 320px, 375px, and 390px.

## Fix

Stack the top row vertically on mobile, keep horizontal on desktop:

- **Outer Flex** — `direction={{ base: "column", md: "row" }}`, `alignItems={{ base: "stretch", md: "center" }}`, `gap={3}`
- **Inner 'Status: [Select]' group** — same responsive direction, with `alignSelf="flex-start"` on the Box so the label stays left-aligned instead of stretching center
- **Select.Root** — `width={{ base: "100%", md: "200px" }}` so it fills the row when stacked
- **Action buttons** — drop below as a horizontal HStack, full width

## Verification

- Screenshots at 320px, 375px, 390px show clean mobile layout with no overflow
- Desktop layout (≥768px) unchanged from #189
- `pnpm lint` clean
- `pnpm test` 50/50 passing, 100% line coverage maintained

## Stacking

Stacked on #189 — depends on the App root being wrapped in a Box with horizontal padding (commit `a96de47`) and on the redesigned `DownloadableItem` (commit `ac043fd`). Merge #189 first, then this one.